### PR TITLE
fix: incorrect aws region variable

### DIFF
--- a/detector.tf
+++ b/detector.tf
@@ -17,7 +17,7 @@ resource "aws_guardduty_publishing_destination" "eu_west_1" {
 
 resource "aws_guardduty_detector" "eu_west_2" {
   enable                       = true
-  provider                     = aws
+  provider                     = aws.eu-west-2
   finding_publishing_frequency = var.publishing_frequency
 }
 


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2482

I believe that this provcider variable is incorrect and this fix could help us make progress on this failed drone build:
https://drone-gl.acp.homeoffice.gov.uk/acp/acp-ops-resources/3160/1/3