### PR TITLE
ACPENG-2431 fix replication kms encryption config

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -70,6 +70,10 @@ resource "aws_s3_bucket_replication_configuration" "guardduty_bucket_replication
     destination {
       bucket        = var.replication_destination_bucket_arn
       storage_class = "STANDARD"
+
+      encryption_configuration {
+        replica_kms_key_id = var.replication_destination_kms_arn
+      }
     }
 
     source_selection_criteria {


### PR DESCRIPTION
Need to push to the ACP OPs repository as part of https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2431

I noticed this error in the last push to master - https://drone-gl.acp.homeoffice.gov.uk/acp/acp-ops-resources/3202/1/3 :
```
│ Error: error creating S3 replication configuration for bucket (acp-guardduty-aggregation-ops-prod-eu-west-2): InvalidRequest: ReplicaKmsKeyID must be specified if SseKmsEncryptedObjects tag is present.
│ 	status code: 400, request id: 3SV87GHZM7TRBW42, host id: GtuMLO5nJnTtd8km5x9oFXaa8gE9AVadIlIThlLlrxJuapVO14YqYYrZrjPCY2v2HqYqmUqxpm5rTuYEPKRZlkNlPXmFzIfgO67LBycmZPU=
│ 
│   with module.guardduty_master_account_ops.aws_s3_bucket_replication_configuration.guardduty_bucket_replication,
│   on .terraform/modules/guardduty_master_account_ops/bucket.tf line 62, in resource "aws_s3_bucket_replication_configuration" "guardduty_bucket_replication":
│   62: resource "aws_s3_bucket_replication_configuration" "guardduty_bucket_replication" {
│ 
```

Wanted to fix it.